### PR TITLE
ゲストユーザー制限機能を実装

### DIFF
--- a/src/__tests__/components/CreateGoal.guest-restrictions.test.js
+++ b/src/__tests__/components/CreateGoal.guest-restrictions.test.js
@@ -1,0 +1,127 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/router';
+import NewGoalModal from '../../components/CreateGoal';
+import { fetchWithAuth } from '../../utils/fetchWithAuth';
+
+// Mock外部依存関係
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../../utils/fetchWithAuth');
+
+const mockRouter = {
+  push: jest.fn(),
+};
+
+// ユーザーデータをprops経由で受け取るテスト用ラッパー
+const CreateGoalWrapper = ({ isOpen, onClose, userData }) => {
+  return (
+    <div>
+      {/* ゲスト制限を適用したNewGoalModal */}
+      <NewGoalModal 
+        isOpen={isOpen} 
+        onClose={onClose}
+        userData={userData}
+      />
+    </div>
+  );
+};
+
+describe('CreateGoal - ゲスト制限機能', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue(mockRouter);
+    jest.clearAllMocks();
+  });
+
+  describe('Goal入力制限', () => {
+    test('通常ユーザー（is_guest: false）の場合、Goal作成フォームが正常に動作する', async () => {
+      const userData = {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'user@example.com',
+        is_guest: false
+      };
+
+      render(<CreateGoalWrapper isOpen={true} onClose={() => {}} userData={userData} />);
+
+      // フォーム要素が存在し、入力可能であることを確認
+      const titleInput = screen.getByLabelText(/Goalのタイトル/i);
+      const contentTextarea = screen.getByLabelText(/Goalの詳細/i);
+      const deadlineInput = screen.getByLabelText(/期限/i);
+      const submitButton = screen.getByText('設定する');
+
+      expect(titleInput).toBeInTheDocument();
+      expect(titleInput).not.toBeDisabled();
+      expect(contentTextarea).toBeInTheDocument();
+      expect(contentTextarea).not.toBeDisabled();
+      expect(deadlineInput).toBeInTheDocument();
+      expect(deadlineInput).not.toBeDisabled();
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).not.toBeDisabled();
+
+      // 入力が可能であることを確認
+      fireEvent.change(titleInput, { target: { value: 'テストゴール' } });
+      expect(titleInput.value).toBe('テストゴール');
+    });
+
+    test('ゲストユーザー（is_guest: true）の場合、フォーム入力が制限される', async () => {
+      const userData = {
+        id: 1,
+        name: 'ゲストユーザー',
+        email: 'guest@example.com',
+        is_guest: true
+      };
+
+      render(<CreateGoalWrapper isOpen={true} onClose={() => {}} userData={userData} />);
+
+      // フォーム要素が無効化されていることを確認
+      const titleInput = screen.getByLabelText(/Goalのタイトル/i);
+      const contentTextarea = screen.getByLabelText(/Goalの詳細/i);
+      const deadlineInput = screen.getByLabelText(/期限/i);
+      const submitButton = screen.getByText('設定する');
+
+      expect(titleInput).toBeDisabled();
+      expect(contentTextarea).toBeDisabled();
+      expect(deadlineInput).toBeDisabled();
+      expect(submitButton).toBeDisabled();
+
+      // ゲスト制限メッセージが表示されることを確認
+      expect(screen.getByText('不適切な投稿を避けるため、入力できません')).toBeInTheDocument();
+    });
+
+    test('ゲストユーザーが入力フィールドにフォーカスした際、警告メッセージが表示される', async () => {
+      const userData = {
+        id: 1,
+        name: 'ゲストユーザー',
+        email: 'guest@example.com',
+        is_guest: true
+      };
+
+      render(<CreateGoalWrapper isOpen={true} onClose={() => {}} userData={userData} />);
+
+      // 警告メッセージが表示されることを確認
+      expect(screen.getByText('不適切な投稿を避けるため、入力できません')).toBeInTheDocument();
+    });
+
+    test('ゲストユーザーがフォーム送信を試みても送信されない', async () => {
+      const userData = {
+        id: 1,
+        name: 'ゲストユーザー',
+        email: 'guest@example.com',
+        is_guest: true
+      };
+
+      render(<CreateGoalWrapper isOpen={true} onClose={() => {}} userData={userData} />);
+
+      const submitButton = screen.getByText('設定する');
+      expect(submitButton).toBeDisabled();
+
+      // フォーム送信がされないことを確認
+      fireEvent.click(submitButton);
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/__tests__/components/EditUserNameModal.guest-restrictions.test.js
+++ b/src/__tests__/components/EditUserNameModal.guest-restrictions.test.js
@@ -1,0 +1,179 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/router';
+import EditUserNameModal from '../../components/EditUserNameModal';
+import { fetchWithAuth } from '../../utils/fetchWithAuth';
+
+// Mock外部依存関係
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('../../utils/fetchWithAuth');
+
+const mockRouter = {
+  push: jest.fn(),
+};
+
+describe('EditUserNameModal - ゲスト制限機能', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue(mockRouter);
+    jest.clearAllMocks();
+  });
+
+  describe('ユーザーネーム編集制限', () => {
+    test('通常ユーザー（is_guest: false）の場合、ユーザーネーム編集フォームが正常に動作する', async () => {
+      const userData = {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'user@example.com',
+        is_guest: false
+      };
+
+      render(
+        <EditUserNameModal
+          isOpen={true}
+          onClose={() => {}}
+          currentName="テストユーザー"
+          onUserUpdate={() => {}}
+          userData={userData}
+        />
+      );
+
+      // フォーム要素が存在し、入力可能であることを確認
+      const nameInput = screen.getByDisplayValue('テストユーザー');
+      const submitButton = screen.getByText('変更');
+
+      expect(nameInput).toBeInTheDocument();
+      expect(nameInput).not.toBeDisabled();
+      expect(submitButton).toBeInTheDocument();
+      expect(submitButton).not.toBeDisabled();
+
+      // 入力が可能であることを確認
+      fireEvent.change(nameInput, { target: { value: '新しい名前' } });
+      expect(nameInput.value).toBe('新しい名前');
+    });
+
+    test('ゲストユーザー（is_guest: true）の場合、フォーム入力が制限される', async () => {
+      const userData = {
+        id: 1,
+        name: 'ゲストユーザー',
+        email: 'guest@example.com',
+        is_guest: true
+      };
+
+      render(
+        <EditUserNameModal
+          isOpen={true}
+          onClose={() => {}}
+          currentName="ゲストユーザー"
+          onUserUpdate={() => {}}
+          userData={userData}
+        />
+      );
+
+      // フォーム要素が無効化されていることを確認
+      const nameInput = screen.getByDisplayValue('ゲストユーザー');
+      const submitButton = screen.getByText('変更');
+
+      expect(nameInput).toBeDisabled();
+      expect(submitButton).toBeDisabled();
+
+      // ゲスト制限メッセージが表示されることを確認
+      expect(screen.getByText('不適切な投稿を避けるため、入力できません')).toBeInTheDocument();
+    });
+
+    test('ゲストユーザーが入力フィールドにフォーカスした際、警告メッセージが表示される', async () => {
+      const userData = {
+        id: 1,
+        name: 'ゲストユーザー',
+        email: 'guest@example.com',
+        is_guest: true
+      };
+
+      render(
+        <EditUserNameModal
+          isOpen={true}
+          onClose={() => {}}
+          currentName="ゲストユーザー"
+          onUserUpdate={() => {}}
+          userData={userData}
+        />
+      );
+
+      // 警告メッセージが表示されることを確認
+      expect(screen.getByText('不適切な投稿を避けるため、入力できません')).toBeInTheDocument();
+    });
+
+    test('ゲストユーザーがフォーム送信を試みても送信されない', async () => {
+      const userData = {
+        id: 1,
+        name: 'ゲストユーザー',
+        email: 'guest@example.com',
+        is_guest: true
+      };
+
+      render(
+        <EditUserNameModal
+          isOpen={true}
+          onClose={() => {}}
+          currentName="ゲストユーザー"
+          onUserUpdate={() => {}}
+          userData={userData}
+        />
+      );
+
+      const submitButton = screen.getByText('変更');
+      expect(submitButton).toBeDisabled();
+
+      // フォーム送信がされないことを確認
+      fireEvent.click(submitButton);
+      expect(fetchWithAuth).not.toHaveBeenCalled();
+    });
+
+    test('通常ユーザーがフォーム送信すると正常に送信される', async () => {
+      const userData = {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'user@example.com',
+        is_guest: false
+      };
+
+      fetchWithAuth.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ user: { name: '更新されたユーザー' } })
+      });
+
+      const onUserUpdate = jest.fn();
+      const onClose = jest.fn();
+
+      render(
+        <EditUserNameModal
+          isOpen={true}
+          onClose={onClose}
+          currentName="テストユーザー"
+          onUserUpdate={onUserUpdate}
+          userData={userData}
+        />
+      );
+
+      const nameInput = screen.getByDisplayValue('テストユーザー');
+      const submitButton = screen.getByText('変更');
+
+      // 名前を変更
+      fireEvent.change(nameInput, { target: { value: '更新されたユーザー' } });
+      
+      // フォーム送信
+      fireEvent.click(submitButton);
+
+      await waitFor(() => {
+        expect(fetchWithAuth).toHaveBeenCalledWith('/api/current_user', {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ user: { name: '更新されたユーザー' } })
+        });
+      });
+    });
+  });
+});

--- a/src/__tests__/components/Header.guest-restrictions.test.js
+++ b/src/__tests__/components/Header.guest-restrictions.test.js
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { useRouter } from 'next/router';
+import { useAuthenticator } from '@aws-amplify/ui-react';
+import Header from '../../components/Header';
+import { fetchWithAuth } from '../../utils/fetchWithAuth';
+
+// Mock外部依存関係
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(),
+}));
+
+jest.mock('@aws-amplify/ui-react', () => ({
+  useAuthenticator: jest.fn(),
+}));
+
+jest.mock('../../utils/fetchWithAuth');
+jest.mock('aws-amplify/auth', () => ({
+  signOut: jest.fn(),
+  updateUserAttributes: jest.fn(),
+}));
+
+const mockRouter = {
+  push: jest.fn(),
+  pathname: '/',
+};
+
+const mockSignOut = jest.fn();
+
+describe('Header - ゲスト制限機能', () => {
+  beforeEach(() => {
+    useRouter.mockReturnValue(mockRouter);
+    useAuthenticator.mockReturnValue({
+      signOut: mockSignOut,
+    });
+    jest.clearAllMocks();
+  });
+
+  describe('退会ボタンの表示制御', () => {
+    test('通常ユーザー（is_guest: false）の場合、退会ボタンが表示される', async () => {
+      // 通常ユーザーのAPIレスポンスをモック
+      fetchWithAuth.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 1,
+          name: 'テストユーザー',
+          email: 'user@example.com',
+          is_guest: false
+        })
+      });
+
+      render(<Header />);
+
+      // ログイン状態になるまで待機
+      await waitFor(() => {
+        expect(fetchWithAuth).toHaveBeenCalledWith('/api/current_user');
+      });
+
+      // ハンバーガーメニューを開く
+      const hamburgerButton = screen.getByRole('button');
+      fireEvent.click(hamburgerButton);
+
+      // 退会ボタンが表示されることを確認
+      await waitFor(() => {
+        expect(screen.getByText('退会')).toBeInTheDocument();
+      });
+    });
+
+    test('ゲストユーザー（is_guest: true）の場合、退会ボタンが表示されない', async () => {
+      // ゲストユーザーのAPIレスポンスをモック
+      fetchWithAuth.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          id: 1,
+          name: 'ゲストユーザー',
+          email: 'guest@example.com',
+          is_guest: true
+        })
+      });
+
+      render(<Header />);
+
+      // ログイン状態になるまで待機
+      await waitFor(() => {
+        expect(fetchWithAuth).toHaveBeenCalledWith('/api/current_user');
+      });
+
+      // ハンバーガーメニューを開く
+      const hamburgerButton = screen.getByRole('button');
+      fireEvent.click(hamburgerButton);
+
+      // 退会ボタンが表示されないことを確認
+      await waitFor(() => {
+        expect(screen.queryByText('退会')).not.toBeInTheDocument();
+      });
+
+      // 他のメニュー項目は表示されることを確認
+      expect(screen.getByText('ダッシュボード')).toBeInTheDocument();
+      expect(screen.getByText('ログアウト')).toBeInTheDocument();
+    });
+
+    test('APIエラーの場合、ログインしていない状態として扱われる', async () => {
+      // API呼び出しが失敗した場合をモック
+      fetchWithAuth.mockRejectedValue(new Error('API Error'));
+
+      render(<Header />);
+
+      // ログイン前のメニューが表示されることを確認
+      await waitFor(() => {
+        const hamburgerButton = screen.getByRole('button');
+        fireEvent.click(hamburgerButton);
+        
+        expect(screen.getByText('ログイン')).toBeInTheDocument();
+        expect(screen.queryByText('退会')).not.toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/components/CreateGoal.js
+++ b/src/components/CreateGoal.js
@@ -5,14 +5,24 @@ import styles from '../components/CreateGoal.module.css';
 
 import { fetchWithAuth } from '../utils/fetchWithAuth';
 
-export default function NewGoalModal({ isOpen, onClose }) {
+export default function NewGoalModal({ isOpen, onClose, userData = null }) {
   const router = useRouter();
   const [title, setTitle] = useState('');
   const [content, setContent] = useState('');
   const [deadline, setDeadline] = useState('');
+  const [showGuestWarning, setShowGuestWarning] = useState(false);
+
+  const isGuestUser = userData?.is_guest || false;
 
   const handleSubmit = async (event) => {
     event.preventDefault();
+    
+    // ゲストユーザーの場合は送信を阻止
+    if (isGuestUser) {
+      setShowGuestWarning(true);
+      return;
+    }
+
     const body = JSON.stringify({ title, content, deadline });
 
     try {
@@ -36,6 +46,12 @@ export default function NewGoalModal({ isOpen, onClose }) {
     }
   };
 
+  const handleGuestFocus = () => {
+    if (isGuestUser) {
+      setShowGuestWarning(true);
+    }
+  };
+
   if (!isOpen) return null;
 
   return (
@@ -51,6 +67,13 @@ export default function NewGoalModal({ isOpen, onClose }) {
 
         {/* スクロール可能なコンテンツ部分 */}
         <div className="flex-1 overflow-y-auto py-4">
+          {/* ゲスト制限警告メッセージ */}
+          {isGuestUser && (
+            <div className="mb-4 p-3 bg-gray-100 border border-gray-300 rounded text-sm text-gray-600">
+              不適切な投稿を避けるため、入力できません
+            </div>
+          )}
+          
           <form onSubmit={handleSubmit} className="space-y-4 space-y-reverse">
             <div>
               <label htmlFor="title" className="block mb-2 text-base">Goalのタイトル</label>
@@ -60,9 +83,14 @@ export default function NewGoalModal({ isOpen, onClose }) {
                 type="text"
                 value={title}
                 onChange={(e) => setTitle(e.target.value)}
+                onFocus={handleGuestFocus}
+                disabled={isGuestUser}
                 required
-                className={`${styles.textareaField} w-full text-sm sm:text-base`}
+                className={`${styles.textareaField} w-full text-sm sm:text-base ${
+                  isGuestUser ? 'bg-gray-100 cursor-not-allowed opacity-50' : ''
+                }`}
                 rows={2}
+                placeholder={isGuestUser ? "ゲストユーザーは入力できません" : ""}
               />
             </div>
 
@@ -74,9 +102,14 @@ export default function NewGoalModal({ isOpen, onClose }) {
                 type="text"
                 value={content}
                 onChange={(e) => setContent(e.target.value)}
+                onFocus={handleGuestFocus}
+                disabled={isGuestUser}
                 required
-                className={`${styles.textareaField} w-full text-sm sm:text-base`}
+                className={`${styles.textareaField} w-full text-sm sm:text-base ${
+                  isGuestUser ? 'bg-gray-100 cursor-not-allowed opacity-50' : ''
+                }`}
                 rows={2}
+                placeholder={isGuestUser ? "ゲストユーザーは入力できません" : ""}
               />
             </div>
 
@@ -88,12 +121,24 @@ export default function NewGoalModal({ isOpen, onClose }) {
                 type="date"
                 value={deadline}
                 onChange={(e) => setDeadline(e.target.value)}
+                onFocus={handleGuestFocus}
+                disabled={isGuestUser}
                 required
-                className={`${styles.deadlineField} w-full text-sm sm:text-base`}
+                className={`${styles.deadlineField} w-full text-sm sm:text-base ${
+                  isGuestUser ? 'bg-gray-100 cursor-not-allowed opacity-50' : ''
+                }`}
               />
             </div>
 
-            <button type="submit" className="btn btn-primary w-full sm:w-auto">設定する</button>
+            <button 
+              type="submit" 
+              disabled={isGuestUser}
+              className={`btn btn-primary w-full sm:w-auto ${
+                isGuestUser ? 'opacity-50 cursor-not-allowed' : ''
+              }`}
+            >
+              設定する
+            </button>
           </form>
         </div>
         

--- a/src/components/EditUserNameModal.js
+++ b/src/components/EditUserNameModal.js
@@ -4,15 +4,24 @@ import styles from '../components/CreateGoal.module.css';
 
 import { fetchWithAuth } from '../utils/fetchWithAuth';
 
-export default function EditUserNameModal({ isOpen, onClose, currentName, onUserUpdate }) {
+export default function EditUserNameModal({ isOpen, onClose, currentName, onUserUpdate, userData = null }) {
   const router = useRouter();
 
   const [newName, setNewName] = useState(currentName || '');
+  const [showGuestWarning, setShowGuestWarning] = useState(false);
+
+  const isGuestUser = userData?.is_guest || false;
 
   if (!isOpen) return null;
 
   const handleSubmit = async (event) => {
     event.preventDefault();
+
+    // ゲストユーザーの場合は送信を阻止
+    if (isGuestUser) {
+      setShowGuestWarning(true);
+      return;
+    }
 
     const body = JSON.stringify({
       user: { name: newName }
@@ -46,10 +55,24 @@ export default function EditUserNameModal({ isOpen, onClose, currentName, onUser
     }
   };
 
+  const handleGuestFocus = () => {
+    if (isGuestUser) {
+      setShowGuestWarning(true);
+    }
+  };
+
   return (
     <div className={styles.modalOverlay}>
       <div className={styles.modalContent}>
         <h2>ユーザー名を編集する</h2>
+        
+        {/* ゲスト制限警告メッセージ */}
+        {isGuestUser && (
+          <div className="mb-4 p-3 bg-gray-100 border border-gray-300 rounded text-sm text-gray-600">
+            不適切な投稿を避けるため、入力できません
+          </div>
+        )}
+        
         <form onSubmit={handleSubmit}>
           <label htmlFor="username">新しいユーザー名を入力してください。</label>
           <textarea
@@ -57,12 +80,25 @@ export default function EditUserNameModal({ isOpen, onClose, currentName, onUser
             name="username"
             rows={2}
             cols={50}
-            className={styles.textareaField}
+            className={`${styles.textareaField} ${
+              isGuestUser ? 'bg-gray-100 cursor-not-allowed opacity-50' : ''
+            }`}
             value={newName}
             onChange={(e) => setNewName(e.target.value)}
+            onFocus={handleGuestFocus}
+            disabled={isGuestUser}
+            placeholder={isGuestUser ? "ゲストユーザーは入力できません" : ""}
             required
           />
-          <button type="submit" className="btn btn-primary">変更</button>
+          <button 
+            type="submit" 
+            disabled={isGuestUser}
+            className={`btn btn-primary ${
+              isGuestUser ? 'opacity-50 cursor-not-allowed' : ''
+            }`}
+          >
+            変更
+          </button>
         </form>
 
         {/* キャンセル用ボタン */}

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -11,15 +11,24 @@ const Header = () => {
   
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [userData, setUserData] = useState(null);
 
   // 認証状態をチェック
   useEffect(() => {
     const checkAuth = async () => {
       try {
         const res = await fetchWithAuth('/api/current_user');
-        setIsLoggedIn(res.ok);
+        if (res.ok) {
+          const data = await res.json();
+          setUserData(data);
+          setIsLoggedIn(true);
+        } else {
+          setIsLoggedIn(false);
+          setUserData(null);
+        }
       } catch {
         setIsLoggedIn(false);
+        setUserData(null);
       }
     };
     checkAuth();
@@ -136,7 +145,10 @@ const Header = () => {
               <Link href="/dashboard" className="py-3 text-[#373741] hover:text-blue-600 border-b border-gray-200" onClick={() => setIsMobileMenuOpen(false)}>ダッシュボード</Link>
               <Link href="https://qiita.com/NaaaRiii/items/b79753445554530fafd7" target="_blank" rel="noopener noreferrer" className="py-3 text-[#373741] hover:text-blue-600 border-b border-gray-200" onClick={() => setIsMobileMenuOpen(false)}>使い方</Link>
               <a href="/logout" onClick={(e) => { handleLogout(e); setIsMobileMenuOpen(false); }} className="py-3 text-[#373741] hover:text-blue-600 border-b border-gray-200">ログアウト</a>
-              <button onClick={handleWithdrawal} className="py-3 text-[#373741] hover:text-red-600 text-left">退会</button>
+              {/* ゲストユーザーの場合は退会ボタンを非表示 */}
+              {!userData?.is_guest && (
+                <button onClick={handleWithdrawal} className="py-3 text-[#373741] hover:text-red-600 text-left">退会</button>
+              )}
             </>
           ) : (
             <>

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -253,6 +253,8 @@ return (
                       isOpen={isEditNameOpen} 
                       onClose={closeEditName} 
                       onUserUpdate={handleUserUpdate}
+                      currentName={userData?.name}
+                      userData={userData}
                     />
                     <div className='user-profile__roulette'>
                       {userRank >= 10 && (
@@ -289,7 +291,7 @@ return (
               <Link href="/new-goal" onClick={handleOpenModal} className="block sm:inline-block">
                 <div className='btn btn-primary w-full sm:w-auto'>Goalを設定する</div>
               </Link>
-              <NewGoalModal isOpen={isModalOpen} onClose={handleCloseModal} />
+              <NewGoalModal isOpen={isModalOpen} onClose={handleCloseModal} userData={userData} />
               <Link href="/completed-goal" className="block sm:inline-block">
                 <div className='btn btn-primary w-full sm:w-auto'>達成したGoal</div>
               </Link>


### PR DESCRIPTION
・ ヘッダーナビゲーションでゲストユーザーには退会ボタンを非表示
・ Goal/SmallGoal作成フォームでゲストユーザーの入力を制限
・ ユーザーネーム編集でゲストユーザーの編集を制限
・ 制限メッセージ「不適切な投稿を避けるため、入力できません」を表示
・ ゲスト制限機能の包括的なテストを追加
・ 既存のHeaderテストを現在の実装に合わせて更新